### PR TITLE
CI-206 include spcc in overdue email

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,17 +1,11 @@
 var Date = {
   startOfDay: function(d) {
-    d.setHours(0);
-    d.setMinutes(0);
-    d.setSeconds(0);
-    d.setMilliseconds(0);
+    d.setUTCHours(0, 0, 0, 0);
     return d;
   },
 
   endOfDay: function(d) {
-    d.setHours(23);
-    d.setMinutes(59);
-    d.setSeconds(59);
-    d.setMilliseconds(999);
+    d.setUTCHours(23, 59, 59, 999);
     return d;
   },
 
@@ -27,66 +21,66 @@ var Date = {
   },
 
   startOfWeek: function(d) {
-    var dayOfWeek = d.getDay();
-    var dayInMonth = d.getDate();
+    var dayOfWeek = d.getUTCDay();
+    var dayInMonth = d.getUTCDate();
 
     if (dayOfWeek >= dayInMonth) {
-      d.setDate(dayInMonth - dayOfWeek);
+      d.setUTCDate(dayInMonth - dayOfWeek);
       return this.startOfDay(d);
     }
-    var month = d.getMonth();
-    var year = d.getFullYear();
+    var month = d.getUTCMonth();
+    var year = d.getUTCFullYear();
     if (month > 0) {
-      d.setMonth(month - 1);
+      d.setUTCMonth(month - 1);
     } else {
-      d.setMonth(11);
-      d.setFullYear(year - 1);
+      d.setUTCMonth(11);
+      d.setUTCFullYear(year - 1);
     }
-    var daysInMonth = this.getDaysInMonth(d.getMonth(), year);
-    d.setDate(daysInMonth + dayInMonth - dayOfWeek);
+    var daysInMonth = this.getDaysInMonth(d.getUTCMonth(), year);
+    d.setUTCDate(daysInMonth + dayInMonth - dayOfWeek);
     return this.startOfDay(d);
 
   },
 
   endOfWeek: function(d) {
-    var dayOfWeek = d.getDay();
-    var dayInMonth = d.getDate();
-    var year = d.getFullYear();
-    var month = d.getMonth();
-    var daysInMonth = this.getDaysInMonth(d.getMonth(), year);
+    var dayOfWeek = d.getUTCDay();
+    var dayInMonth = d.getUTCDate();
+    var year = d.getUTCFullYear();
+    var month = d.getUTCMonth();
+    var daysInMonth = this.getDaysInMonth(d.getUTCMonth(), year);
 
     if (dayInMonth + 6 - dayOfWeek <= daysInMonth) {
-      d.setDate(dayInMonth + 6 - dayOfWeek);
+      d.setUTCDate(dayInMonth + 6 - dayOfWeek);
       return this.endOfDay(d);
     }
 
     if (month < 11) {
-      d.setMonth(month + 1);
+      d.setUTCMonth(month + 1);
     } else {
-      d.setMonth(0);
-      d.setFullYear(year + 1);
+      d.setUTCMonth(0);
+      d.setUTCFullYear(year + 1);
     }
-    d.setDate(dayInMonth + 6 - dayOfWeek - daysInMonth);
+    d.setUTCDate(dayInMonth + 6 - dayOfWeek - daysInMonth);
     return this.endOfDay(d);
   },
 
   startOfMonth: function(d) {
-    d.setDate(1);
+    d.setUTCDate(1);
     return this.startOfDay(d);
   },
 
   endOfMonth: function(d) {
-    d.setDate(this.getDaysInMonth(d.getMonth(), d.getYear()));
+    d.setUTCDate(this.getDaysInMonth(d.getUTCMonth(), d.getUTCFullYear()));
     return this.endOfDay(d);
   },
 
   startOfQuarter: function(d) {
-    d.setMonth(Math.floor(d.getMonth()/3) * 3);
+    d.setUTCMonth(Math.floor(d.getUTCMonth()/3) * 3);
     return this.startOfMonth(d);
   },
 
   endOfQuarter: function(d) {
-    d.setMonth(Math.floor(d.getMonth()/3) * 3 + 2);
+    d.setUTCMonth(Math.floor(d.getUTCMonth()/3) * 3 + 2);
     return this.endOfMonth(d);
   },
 
@@ -95,14 +89,14 @@ var Date = {
       throw new Error('Only implemented to add 11 months!');
     }
 
-    var month = d.getMonth();
+    var month = d.getUTCMonth();
     if (month + numMonths < 12) {
-      d.setMonth(month + numMonths);
+      d.setUTCMonth(month + numMonths);
       return d;
     }
 
-    d.setFullYear(d.getFullYear() + 1);
-    d.setMonth(month + numMonths - 12);
+    d.setUTCFullYear(d.getUTCFullYear() + 1);
+    d.setUTCMonth(month + numMonths - 12);
     return d;
   },
 
@@ -111,22 +105,22 @@ var Date = {
       throw new Error('Only implemented to add less than one month of days!');
     }
 
-    var dayOfMonth = d.getDate();
-    var month = d.getMonth();
-    var year = d.getFullYear();
+    var dayOfMonth = d.getUTCDate();
+    var month = d.getUTCMonth();
+    var year = d.getUTCFullYear();
     var daysInMonth = this.getDaysInMonth(month, year);
     if (dayOfMonth + daysToAdd <= daysInMonth) {
-      d.setDate(dayOfMonth + daysToAdd);
+      d.setUTCDate(dayOfMonth + daysToAdd);
       return d;
     }
 
     if (month < 11) {
-      d.setMonth(month + 1);
+      d.setUTCMonth(month + 1);
     } else {
-      d.setMonth(0);
-      d.setFullYear(year + 1);
+      d.setUTCMonth(0);
+      d.setUTCFullYear(year + 1);
     }
-    d.setDate(dayOfMonth + daysToAdd - daysInMonth);
+    d.setUTCDate(dayOfMonth + daysToAdd - daysInMonth);
     return d;
   },
 
@@ -135,27 +129,27 @@ var Date = {
       throw new Error('Only implemented to subtract less than one month of days!');
     }
 
-    var dayOfMonth = d.getDate();
-    var month = d.getMonth();
-    var year = d.getFullYear();
+    var dayOfMonth = d.getUTCDate();
+    var month = d.getUTCMonth();
+    var year = d.getUTCFullYear();
     var daysInMonth = this.getDaysInMonth(month, year);
     if (dayOfMonth - daysToSubtract >= 0) {
-      d.setDate(dayOfMonth - daysToSubtract);
+      d.setUTCDate(dayOfMonth - daysToSubtract);
       return d;
     }
 
     if (month > 0) {
-      d.setMonth(month - 1);
+      d.setUTCMonth(month - 1);
     } else {
-      d.setMonth(11);
-      d.setFullYear(year - 1);
+      d.setUTCMonth(11);
+      d.setUTCFullYear(year - 1);
     }
-    d.setDate(dayOfMonth - daysToSubtract + daysInMonth);
+    d.setUTCDate(dayOfMonth - daysToSubtract + daysInMonth);
     return d;
   },
 
   isSameDay: function(d1, d2) {
-    return d1.getFullYear() === d2.getFullYear() && d1.getMonth() === d2.getMonth() && d1.getDate() === d2.getDate();
+    return d1.getUTCFullYear() === d2.getUTCFullYear() && d1.getUTCMonth() === d2.getUTCMonth() && d1.getUTCDate() === d2.getUTCDate();
   },
 
   isBetween: function(x, d1, d2) {
@@ -163,7 +157,7 @@ var Date = {
   },
 
   dayOfWeek: function(d, dayOfWeek) {
-    var currentDayOfWeek = d.getDay();
+    var currentDayOfWeek = d.getUTCDay();
 
     if (currentDayOfWeek < dayOfWeek) {
       return this.addLessThan29Days(d, dayOfWeek - currentDayOfWeek);
@@ -174,7 +168,7 @@ var Date = {
   },
 
   getMonthName: function(d) {
-    var month = d.getMonth();
+    var month = d.getUTCMonth();
     switch(month) {
       case 0:
         return 'January';
@@ -204,13 +198,13 @@ var Date = {
   },
 
   getDayOfYear: function(d){
-    var month = d.getMonth();
+    var month = d.getUTCMonth();
     var i = 0;
     var dayOfYear = 0;
     while (i < month) {
       dayOfYear += this.getDaysInMonth(i++);
     }
-    return dayOfYear + d.getDate();
+    return dayOfYear + d.getUTCDate();
   },
 
   getWeekOfYear: function(d){
@@ -228,7 +222,7 @@ var Date = {
 
 
   getQuarter: function(d) {
-    return Math.floor(d.getMonth()/3) + 1;
+    return Math.floor(d.getUTCMonth()/3) + 1;
   },
 
   _addZeroAtFront: function(n) {
@@ -239,16 +233,16 @@ var Date = {
   },
 
   getTwoCharDate: function(d) {
-    return this._addZeroAtFront(d.getDate());
+    return this._addZeroAtFront(d.getUTCDate());
   },
 
   getTwoCharMonth: function(d) {
-    return this._addZeroAtFront(d.getMonth() + 1);
+    return this._addZeroAtFront(d.getUTCMonth() + 1);
   },
 
   isBeforeDay: function(d1, d2) {
-    var y1 = d1.getFullYear();
-    var y2 = d2.getFullYear();
+    var y1 = d1.getUTCFullYear();
+    var y2 = d2.getUTCFullYear();
     if (y1 !== y2) return y1 < y2;
     return this.getDayOfYear(d1) < this.getDayOfYear(d2);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,206 @@
+{
+  "name": "mapistry-date",
+  "version": "0.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
+    "chai": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "requires": {
+        "type-detect": "0.1.1"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+          "dev": true
+        }
+      }
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "expect.js": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/expect.js/-/expect.js-0.3.1.tgz",
+      "integrity": "sha1-sKWaDS7/VDdUTr8M6qYBWEHQm1s=",
+      "dev": true
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      }
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      }
+    },
+    "moment": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.1.tgz",
+      "integrity": "sha512-shJkRTSebXvsVqk56I+lkb2latjBs8I+pc2TzWc545y2iFnSjm7Wg0QMh+ZWcdSLQyGEau5jI8ocnmkyTgr9YQ==",
+      "dev": true
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "dev": true
+    }
+  }
+}

--- a/test.js
+++ b/test.js
@@ -6,63 +6,63 @@ var MapistryTime = require('./index');
 describe('time library', function() {
   describe('startOfDay', function() {
     it('correctly calculates start of day', function() {
-      var m = moment().month(8).date(13).year(2016);
+      var m = moment.utc().month(8).date(13).year(2016);
       var s = MapistryTime.startOfDay(new Date(m.format()));
       m  = m.startOf('day');
-      expect(s.getDate()).to.be(m.date());
-      expect(s.getMonth()).to.be(m.month());
-      expect(s.getFullYear()).to.be(m.year());
-      expect(s.getHours()).to.be(m.hour());
-      expect(s.getSeconds()).to.be(m.second());
+      expect(s.getUTCDate()).to.be(m.date());
+      expect(s.getUTCMonth()).to.be(m.month());
+      expect(s.getUTCFullYear()).to.be(m.year());
+      expect(s.getUTCHours()).to.be(m.hour());
+      expect(s.getUTCSeconds()).to.be(m.second());
     });
   });
 
   describe('endOfDay', function() {
     it('correctly calculates end of day', function() {
-      var m = moment().month(8).date(13).year(2016);
+      var m = moment.utc().month(8).date(13).year(2016);
       var s = MapistryTime.endOfDay(new Date(m.format()));
       m  = m.endOf('day');
-      expect(s.getDate()).to.be(m.date());
-      expect(s.getMonth()).to.be(m.month());
-      expect(s.getFullYear()).to.be(m.year());
-      expect(s.getHours()).to.be(m.hour());
-      expect(s.getSeconds()).to.be(m.second());
+      expect(s.getUTCDate()).to.be(m.date());
+      expect(s.getUTCMonth()).to.be(m.month());
+      expect(s.getUTCFullYear()).to.be(m.year());
+      expect(s.getUTCHours()).to.be(m.hour());
+      expect(s.getUTCSeconds()).to.be(m.second());
     });
   });
 
   describe('startOfWeek', function() {
     describe ('correctly calculates start of week', function() {
       it('for day at the beginning of week', function () {
-        var m = moment().month(6).date(9).year(2017);
+        var m = moment.utc().month(6).date(9).year(2017);
         var s = MapistryTime.startOfWeek(new Date(m.format()));
         m = m.startOf('week');
-        expect(s.getDate()).to.be(m.date());
-        expect(s.getMonth()).to.be(m.month());
-        expect(s.getFullYear()).to.be(m.year());
-        expect(s.getHours()).to.be(m.hour());
-        expect(s.getSeconds()).to.be(m.second());
+        expect(s.getUTCDate()).to.be(m.date());
+        expect(s.getUTCMonth()).to.be(m.month());
+        expect(s.getUTCFullYear()).to.be(m.year());
+        expect(s.getUTCHours()).to.be(m.hour());
+        expect(s.getUTCSeconds()).to.be(m.second());
       });
 
       it('for week at the beginning of the month', function () {
-        var m = moment().month(5).date(1).year(2017);
+        var m = moment.utc().month(5).date(1).year(2017);
         var s = MapistryTime.startOfWeek(new Date(m.format()));
         m = m.startOf('week');
-        expect(s.getDate()).to.be(m.date());
-        expect(s.getMonth()).to.be(m.month());
-        expect(s.getFullYear()).to.be(m.year());
-        expect(s.getHours()).to.be(m.hour());
-        expect(s.getSeconds()).to.be(m.second());
+        expect(s.getUTCDate()).to.be(m.date());
+        expect(s.getUTCMonth()).to.be(m.month());
+        expect(s.getUTCFullYear()).to.be(m.year());
+        expect(s.getUTCHours()).to.be(m.hour());
+        expect(s.getUTCSeconds()).to.be(m.second());
       });
 
       it('for week at the beginning of the year', function () {
-        var m = moment().month(0).date(1).year(2016);
+        var m = moment.utc().month(0).date(1).year(2016);
         var s = MapistryTime.startOfWeek(new Date(m.format()));
         m = m.startOf('week');
-        expect(s.getDate()).to.be(m.date());
-        expect(s.getMonth()).to.be(m.month());
-        expect(s.getFullYear()).to.be(m.year());
-        expect(s.getHours()).to.be(m.hour());
-        expect(s.getSeconds()).to.be(m.second());
+        expect(s.getUTCDate()).to.be(m.date());
+        expect(s.getUTCMonth()).to.be(m.month());
+        expect(s.getUTCFullYear()).to.be(m.year());
+        expect(s.getUTCHours()).to.be(m.hour());
+        expect(s.getUTCSeconds()).to.be(m.second());
       });
     });
   });
@@ -70,87 +70,87 @@ describe('time library', function() {
   describe('endOfWeek', function() {
     describe ('correctly calculates end of week', function() {
       it('for day at the end of week', function () {
-        var m = moment().month(6).date(15).year(2017);
+        var m = moment.utc().month(6).date(15).year(2017);
         var s = MapistryTime.endOfWeek(new Date(m.format()));
         m = m.endOf('week');
-        expect(s.getDate()).to.be(m.date());
-        expect(s.getMonth()).to.be(m.month());
-        expect(s.getFullYear()).to.be(m.year());
-        expect(s.getHours()).to.be(m.hour());
-        expect(s.getSeconds()).to.be(m.second());
+        expect(s.getUTCDate()).to.be(m.date());
+        expect(s.getUTCMonth()).to.be(m.month());
+        expect(s.getUTCFullYear()).to.be(m.year());
+        expect(s.getUTCHours()).to.be(m.hour());
+        expect(s.getUTCSeconds()).to.be(m.second());
       });
 
       it('for week at the end of the month', function () {
-        var m = moment().month(5).date(29).year(2017);
+        var m = moment.utc().month(5).date(29).year(2017);
         var s = MapistryTime.endOfWeek(new Date(m.format()));
         m = m.endOf('week');
-        expect(s.getDate()).to.be(m.date());
-        expect(s.getMonth()).to.be(m.month());
-        expect(s.getFullYear()).to.be(m.year());
-        expect(s.getHours()).to.be(m.hour());
-        expect(s.getSeconds()).to.be(m.second());
+        expect(s.getUTCDate()).to.be(m.date());
+        expect(s.getUTCMonth()).to.be(m.month());
+        expect(s.getUTCFullYear()).to.be(m.year());
+        expect(s.getUTCHours()).to.be(m.hour());
+        expect(s.getUTCSeconds()).to.be(m.second());
       });
 
       it('for week at the end of the year', function () {
-        var m = moment().month(11).date(12).year(2017);
+        var m = moment.utc().month(11).date(12).year(2017);
         var s = MapistryTime.endOfWeek(new Date(m.format()));
         m = m.endOf('week');
-        expect(s.getDate()).to.be(m.date());
-        expect(s.getMonth()).to.be(m.month());
-        expect(s.getFullYear()).to.be(m.year());
-        expect(s.getHours()).to.be(m.hour());
-        expect(s.getSeconds()).to.be(m.second());
+        expect(s.getUTCDate()).to.be(m.date());
+        expect(s.getUTCMonth()).to.be(m.month());
+        expect(s.getUTCFullYear()).to.be(m.year());
+        expect(s.getUTCHours()).to.be(m.hour());
+        expect(s.getUTCSeconds()).to.be(m.second());
       });
     });
   });
 
   describe('startOfMonth', function() {
     it('correctly calculates start of month', function() {
-      var m = moment().month(6).date(15).year(2017);
+      var m = moment.utc().month(6).date(15).year(2017);
       var s = MapistryTime.startOfMonth(new Date(m.format()));
       m = m.startOf('month');
-      expect(s.getDate()).to.be(m.date());
-      expect(s.getMonth()).to.be(m.month());
-      expect(s.getFullYear()).to.be(m.year());
-      expect(s.getHours()).to.be(m.hour());
-      expect(s.getSeconds()).to.be(m.second());
+      expect(s.getUTCDate()).to.be(m.date());
+      expect(s.getUTCMonth()).to.be(m.month());
+      expect(s.getUTCFullYear()).to.be(m.year());
+      expect(s.getUTCHours()).to.be(m.hour());
+      expect(s.getUTCSeconds()).to.be(m.second());
     });
   });
 
   describe('endOfMonth', function() {
     it('correctly calculates end of month', function() {
-      var m = moment().month(6).date(15).year(2017);
+      var m = moment.utc().month(6).date(15).year(2017);
       var s = MapistryTime.endOfMonth(new Date(m.format()));
       m = m.endOf('month');
-      expect(s.getDate()).to.be(m.date());
-      expect(s.getMonth()).to.be(m.month());
-      expect(s.getFullYear()).to.be(m.year());
-      expect(s.getHours()).to.be(m.hour());
-      expect(s.getSeconds()).to.be(m.second());
+      expect(s.getUTCDate()).to.be(m.date());
+      expect(s.getUTCMonth()).to.be(m.month());
+      expect(s.getUTCFullYear()).to.be(m.year());
+      expect(s.getUTCHours()).to.be(m.hour());
+      expect(s.getUTCSeconds()).to.be(m.second());
     });
   });
 
   describe('startOfQuarter', function() {
     it('correctly calculates start of quarter', function() {
-      var m = moment().month(6).date(15).year(2017);
+      var m = moment.utc().month(6).date(15).year(2017);
       var s = MapistryTime.startOfQuarter(new Date(m.format()));
-      expect(s.getDate()).to.be(1);
-      expect(s.getMonth()).to.be(6);
-      expect(s.getFullYear()).to.be(2017);
-      expect(s.getHours()).to.be(0);
-      expect(s.getSeconds()).to.be(0);
+      expect(s.getUTCDate()).to.be(1);
+      expect(s.getUTCMonth()).to.be(6);
+      expect(s.getUTCFullYear()).to.be(2017);
+      expect(s.getUTCHours()).to.be(0);
+      expect(s.getUTCSeconds()).to.be(0);
     });
   });
 
   describe('endOfQuarter', function() {
     it('correctly calculates end of quarter', function() {
-      var m = moment().month(6).date(15).year(2017);
+      var m = moment.utc().month(6).date(15).year(2017);
       var s = MapistryTime.endOfQuarter(new Date(m.format()));
-      expect(s.getDate()).to.be(30);
-      expect(s.getMonth()).to.be(8);
-      expect(s.getFullYear()).to.be(2017);
-      expect(s.getHours()).to.be(23);
-      expect(s.getSeconds()).to.be(59);
+      expect(s.getUTCDate()).to.be(30);
+      expect(s.getUTCMonth()).to.be(8);
+      expect(s.getUTCFullYear()).to.be(2017);
+      expect(s.getUTCHours()).to.be(23);
+      expect(s.getUTCSeconds()).to.be(59);
     });
   });
 
@@ -176,93 +176,93 @@ describe('time library', function() {
 
   describe('addMonths', function() {
     it('add months so that year does not change', function() {
-      var m = moment().month(6).date(5).year(2017);
+      var m = moment.utc().month(6).date(5).year(2017);
       var s = MapistryTime.addMonths(new Date(m.format()), 2);
       m = m.add(2, 'months');
-      expect(s.getDate()).to.be(m.date());
-      expect(s.getMonth()).to.be(m.month());
-      expect(s.getFullYear()).to.be(m.year());
-      expect(s.getHours()).to.be(m.hour());
-      expect(s.getSeconds()).to.be(m.second());
+      expect(s.getUTCDate()).to.be(m.date());
+      expect(s.getUTCMonth()).to.be(m.month());
+      expect(s.getUTCFullYear()).to.be(m.year());
+      expect(s.getUTCHours()).to.be(m.hour());
+      expect(s.getUTCSeconds()).to.be(m.second());
     });
 
     it('add months so that year does change', function() {
-      var m = moment().month(12).date(5).year(2017);
+      var m = moment.utc().month(12).date(5).year(2017);
       var s = MapistryTime.addMonths(new Date(m.format()), 2);
       m = m.add(2, 'months');
-      expect(s.getDate()).to.be(m.date());
-      expect(s.getMonth()).to.be(m.month());
-      expect(s.getFullYear()).to.be(m.year());
-      expect(s.getHours()).to.be(m.hour());
-      expect(s.getSeconds()).to.be(m.second());
+      expect(s.getUTCDate()).to.be(m.date());
+      expect(s.getUTCMonth()).to.be(m.month());
+      expect(s.getUTCFullYear()).to.be(m.year());
+      expect(s.getUTCHours()).to.be(m.hour());
+      expect(s.getUTCSeconds()).to.be(m.second());
     });
   });
 
   describe('addLessThan29Days', function() {
     it('add two weeks so that year does not change', function() {
-      var m = moment().month(6).date(5).year(2017);
+      var m = moment.utc().month(6).date(5).year(2017);
       var s = MapistryTime.addLessThan29Days(new Date(m.format()), 14);
       m = m.add(2, 'weeks');
-      expect(s.getDate()).to.be(m.date());
-      expect(s.getMonth()).to.be(m.month());
-      expect(s.getFullYear()).to.be(m.year());
-      expect(s.getHours()).to.be(m.hour());
-      expect(s.getSeconds()).to.be(m.second());
+      expect(s.getUTCDate()).to.be(m.date());
+      expect(s.getUTCMonth()).to.be(m.month());
+      expect(s.getUTCFullYear()).to.be(m.year());
+      expect(s.getUTCHours()).to.be(m.hour());
+      expect(s.getUTCSeconds()).to.be(m.second());
     });
 
     it('add two weeks so that year does change', function() {
-      var m = moment().month(12).date(25).year(2017);
+      var m = moment.utc().month(12).date(25).year(2017);
       var s = MapistryTime.addLessThan29Days(new Date(m.format()), 14);
       m = m.add(2, 'weeks');
-      expect(s.getDate()).to.be(m.date());
-      expect(s.getMonth()).to.be(m.month());
-      expect(s.getFullYear()).to.be(m.year());
-      expect(s.getHours()).to.be(m.hour());
-      expect(s.getSeconds()).to.be(m.second());
+      expect(s.getUTCDate()).to.be(m.date());
+      expect(s.getUTCMonth()).to.be(m.month());
+      expect(s.getUTCFullYear()).to.be(m.year());
+      expect(s.getUTCHours()).to.be(m.hour());
+      expect(s.getUTCSeconds()).to.be(m.second());
     });
   });
 
   describe('subtractLessThan29Days', function() {
 
     it('subtract days so that month and year do not change', function() {
-      var m = moment().month(6).date(5).year(2017);
+      var m = moment.utc().month(6).date(5).year(2017);
       var s = MapistryTime.subtractLessThan29Days(new Date(m.format()),2);
       m = m.subtract(2, 'days');
-      expect(s.getDate()).to.be(m.date());
-      expect(s.getMonth()).to.be(m.month());
-      expect(s.getFullYear()).to.be(m.year());
-      expect(s.getHours()).to.be(m.hour());
-      expect(s.getSeconds()).to.be(m.second());
+      expect(s.getUTCDate()).to.be(m.date());
+      expect(s.getUTCMonth()).to.be(m.month());
+      expect(s.getUTCFullYear()).to.be(m.year());
+      expect(s.getUTCHours()).to.be(m.hour());
+      expect(s.getUTCSeconds()).to.be(m.second());
     });
 
     it('subtract days so that month and year do change', function() {
-      var m = moment().month(0).date(5).year(2017);
+      var m = moment.utc().month(0).date(5).year(2017);
       var s = MapistryTime.subtractLessThan29Days(new Date(m.format()),7);
       m = m.subtract(7, 'days');
-      expect(s.getDate()).to.be(m.date());
-      expect(s.getMonth()).to.be(m.month());
-      expect(s.getFullYear()).to.be(m.year());
-      expect(s.getHours()).to.be(m.hour());
-      expect(s.getSeconds()).to.be(m.second());
+      expect(s.getUTCDate()).to.be(m.date());
+      expect(s.getUTCMonth()).to.be(m.month());
+      expect(s.getUTCFullYear()).to.be(m.year());
+      expect(s.getUTCHours()).to.be(m.hour());
+      expect(s.getUTCSeconds()).to.be(m.second());
     });
   });
 
   describe('isSameDay', function() {
     var m2, d2;
     beforeEach(function() {
-      m2 = moment().startOf('day').add(10, 'hours');
+      m2 = moment.utc().startOf('day').add(10, 'hours');
       d2 = new Date(m2.format());
     });
 
     it('returns true if same day', function() {
-      var m1 = moment().startOf('day').add(4, 'hours');
+      var m1 = moment.utc().startOf('day').add(4, 'hours');
       var d1 = new Date(m1.format());
       expect(m1.isSame(m2, 'day')).to.be.ok();
       expect(MapistryTime.isSameDay(d1, d2)).to.be.ok();
     });
 
     it('otherwise returns false', function() {
-      var m1 = moment().startOf('day').subtract(4, 'hours');
+      var m1 = moment.utc().startOf('day').subtract(4, 'hours');
       var d1 = new Date(m1.format());
       expect(m1.isSame(m2, 'day')).to.not.be.ok();
       expect(MapistryTime.isSameDay(d1, d2)).to.not.be.ok();
@@ -272,21 +272,21 @@ describe('time library', function() {
   describe('isBetween', function() {
     var m1, m2, d1, d2;
     beforeEach(function() {
-      m1 = moment().startOf('day').add(4, 'hours');
-      m2 = moment().startOf('day').add(10, 'hours');
+      m1 = moment.utc().startOf('day').add(4, 'hours');
+      m2 = moment.utc().startOf('day').add(10, 'hours');
       d1 = new Date(m1.format());
       d2 = new Date(m2.format());
     });
 
     it('returns true if date is between two dates', function() {
-      var mb = moment().startOf('day').add(6, 'hours');
+      var mb = moment.utc().startOf('day').add(6, 'hours');
       var b = new Date(mb.format());
       expect(mb.isBetween(m1, m2)).to.be.ok();
       expect(MapistryTime.isBetween(b, d1, d2)).to.be.ok();
     });
 
     it('returns false if date is not between two dates', function() {
-      var mb = moment().startOf('day').add(2, 'days');
+      var mb = moment.utc().startOf('day').add(2, 'days');
       var b = new Date(mb.format());
       expect(mb.isBetween(m1, m2)).to.not.be.ok();
       expect(MapistryTime.isBetween(b, d1, d2)).to.not.be.ok();
@@ -295,31 +295,31 @@ describe('time library', function() {
 
   describe('dayOfWeek', function() {
     it('changes day of week to Monday', function() {
-      var m = moment().month(5).date(21).year(2017);
+      var m = moment.utc().month(5).date(21).year(2017);
       var s = MapistryTime.dayOfWeek(new Date(m.format()), 1);
       m = m.isoWeekday(1);
-      expect(s.getDate()).to.be(m.date());
-      expect(s.getMonth()).to.be(m.month());
-      expect(s.getFullYear()).to.be(m.year());
-      expect(s.getHours()).to.be(m.hour());
-      expect(s.getSeconds()).to.be(m.second());
+      expect(s.getUTCDate()).to.be(m.date());
+      expect(s.getUTCMonth()).to.be(m.month());
+      expect(s.getUTCFullYear()).to.be(m.year());
+      expect(s.getUTCHours()).to.be(m.hour());
+      expect(s.getUTCSeconds()).to.be(m.second());
     });
 
     it('changes day of week to Friday', function() {
-      var m = moment().month(5).date(21).year(2017);
+      var m = moment.utc().month(5).date(21).year(2017);
       var s = MapistryTime.dayOfWeek(new Date(m.format()), 5);
       m = m.isoWeekday(5);
-      expect(s.getDate()).to.be(m.date());
-      expect(s.getMonth()).to.be(m.month());
-      expect(s.getFullYear()).to.be(m.year());
-      expect(s.getHours()).to.be(m.hour());
-      expect(s.getSeconds()).to.be(m.second());
+      expect(s.getUTCDate()).to.be(m.date());
+      expect(s.getUTCMonth()).to.be(m.month());
+      expect(s.getUTCFullYear()).to.be(m.year());
+      expect(s.getUTCHours()).to.be(m.hour());
+      expect(s.getUTCSeconds()).to.be(m.second());
     });
   });
 
   describe('getQuarter', function() {
     it ('returns same quarter as moment would', function() {
-      var m = moment().month(5).date(21).year(2017);
+      var m = moment.utc().month(5).date(21).year(2017);
       var d = new Date(m.format());
       expect(MapistryTime.getQuarter(d)).to.be(m.quarter());
     });
@@ -327,7 +327,7 @@ describe('time library', function() {
 
   describe('getDayOfYear', function() {
     it ('returns same day as moment would', function() {
-      var m = moment().month(5).date(21).year(2017);
+      var m = moment.utc().month(5).date(21).year(2017);
       var d = new Date(m.format());
       expect(MapistryTime.getDayOfYear(d)).to.be(parseInt(m.format('DDD')));
     });
@@ -335,7 +335,7 @@ describe('time library', function() {
 
   describe('getWeekOfYear', function() {
     it ('returns same week as moment would', function() {
-      var m = moment().month(5).date(21).year(2017);
+      var m = moment.utc().month(5).date(21).year(2017);
       var d = new Date(m.format());
       expect(MapistryTime.getWeekOfYear(d)).to.be(parseInt(m.format('w')));
     });
@@ -343,7 +343,7 @@ describe('time library', function() {
 
   describe('getShortMonthName', function() {
     it('returns Sep for date in September', function() {
-      var m = moment().month(8).date(21).year(2017);
+      var m = moment.utc().month(8).date(21).year(2017);
       var d = new Date(m.format());
       expect(MapistryTime.getShortMonthName(d)).to.be('Sep');
     })
@@ -351,7 +351,7 @@ describe('time library', function() {
 
   describe('getTwoCharDate', function() {
     it ('returns same week as moment would', function() {
-      var m = moment().month(5).date(21).year(2017);
+      var m = moment.utc().month(5).date(21).year(2017);
       var d = new Date(m.format());
       expect(MapistryTime.getTwoCharDate(d)).to.be(m.format('DD'));
     });
@@ -359,7 +359,7 @@ describe('time library', function() {
 
   describe('getTwoCharMonth', function() {
     it ('returns same week as moment would', function() {
-      var m = moment().month(5).date(21).year(2017);
+      var m = moment.utc().month(5).date(21).year(2017);
       var d = new Date(m.format());
       expect(MapistryTime.getTwoCharMonth(d)).to.be(m.format('MM'));
     });
@@ -367,29 +367,29 @@ describe('time library', function() {
 
   describe('isBeforeDay returns same as moment would', function() {
     it ('days a few apart, d1 < d2', function() {
-      var m1 = moment().month(5).date(21).year(2017);
-      var m2 = moment().month(5).date(26).year(2017);
+      var m1 = moment.utc().month(5).date(21).year(2017);
+      var m2 = moment.utc().month(5).date(26).year(2017);
       var d1 = new Date(m1.format());
       var d2 = new Date(m2.format());
       expect(MapistryTime.isBeforeDay(d1,d2)).to.be(m1.isBefore(d2, 'day'));
     });
     it ('days a few apart, d1 > d2', function() {
-      var m1 = moment().month(5).date(21).year(2017);
-      var m2 = moment().month(5).date(4).year(2017);
+      var m1 = moment.utc().month(5).date(21).year(2017);
+      var m2 = moment.utc().month(5).date(4).year(2017);
       var d1 = new Date(m1.format());
       var d2 = new Date(m2.format());
       expect(MapistryTime.isBeforeDay(d1,d2)).to.be(m1.isBefore(d2, 'day'));
     });
     it ('days years apart', function() {
-      var m1 = moment().month(5).date(21).year(2013);
-      var m2 = moment().month(5).date(4).year(2017);
+      var m1 = moment.utc().month(5).date(21).year(2013);
+      var m2 = moment.utc().month(5).date(4).year(2017);
       var d1 = new Date(m1.format());
       var d2 = new Date(m2.format());
       expect(MapistryTime.isBeforeDay(d1,d2)).to.be(m1.isBefore(d2, 'day'));
     });
     it ('days same, different times', function() {
-      var m1 = moment().month(5).date(21).year(2017).hour(12);
-      var m2 = moment().month(5).date(21).year(2017).hour(10);
+      var m1 = moment.utc().month(5).date(21).year(2017).hour(12);
+      var m2 = moment.utc().month(5).date(21).year(2017).hour(10);
       var d1 = new Date(m1.format());
       var d2 = new Date(m2.format());
       expect(MapistryTime.isBeforeDay(d1,d2)).to.be(m1.isBefore(d2, 'day'));


### PR DESCRIPTION
mapistry/core-issues#206

This PR asserts that we should always work in UTC in the backend and only convert to user local timezones on the frontend when displaying dates.

Dates and times are always a problem and Javascript has some weird stuff in it. If you create a new date: `new Date()` you get a date in UTC: `2018-05-25T14:52:47.209Z` (the Z at the end means UTC - see [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601). If you modify that date with anything like `setMonth` or `setFullYear`, it gets set for the timezone that is currently running the code.

```
let d = new Date();
#> 2018-05-25T14:55:14.555Z

d.setHours(0, 0, 0, 0);
#> 2018-05-25T04:00:00.000Z
```

If, however, we set the hours with the UTC method, we get what we want:

```
let d = new Date();
#> 2018-05-25T14:55:14.555Z

d.setUTCHours(0, 0, 0, 0);
#> 2018-05-25T00:00:00.000Z
```

This likely isn't a problem in production as the Heroku servers default to running in UTC, but it is a problem for development in some circumstances. For example:

```
let d = new Date('2017-07-01');
#> 2017-07-01T00:00:00.000Z

d.setTime(d.getTime() - 1); // this subtracts 1 millisecond to get the very end of the last month
#> 2017-06-30T23:59:59.999Z

d.setMonth(11); // set to the last millisecond of the year
#> 2018-12-31T00:59:59.999Z
```

2 interesting points above: `setTime` does not have a UTC equivalent (because it is working with the long number representation of time and not a date abstraction); and setting the month messed up the hours more than the timezone offset, which means something is wrong with that method. Using `setUTCMonth` fixes the anomaly.

```
d.setUTCMonth(11); // set to the last millisecond of the year
#> 2018-12-31T23:59:59.999Z
```